### PR TITLE
Create new methods, which allow devs to customize MotionToast even further

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/www/sanju/motiontoast/MainActivity.kt
+++ b/app/src/main/java/www/sanju/motiontoast/MainActivity.kt
@@ -2,17 +2,20 @@ package www.sanju.motiontoast
 
 import android.os.Bundle
 import android.view.View
+import android.widget.CompoundButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
 import kotlinx.android.synthetic.main.activity_main.*
 
 
-class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClickListener {
+class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClickListener,
+    CompoundButton.OnCheckedChangeListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        switch_custom_colors?.setOnCheckedChangeListener(this)
         successBtn.setOnClickListener(this)
         errorBtn.setOnClickListener(this)
         warningBtn.setOnClickListener(this)
@@ -26,49 +29,70 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClick
         infoBtn.setOnLongClickListener(this)
         deleteBtn.setOnLongClickListener(this)
         noInternetBtn.setOnLongClickListener(this)
-
-
     }
+
+    private fun setToastColors(newColorsEnabled: Boolean) {
+        if (newColorsEnabled) {
+            MotionToast.setSuccessColor(R.color.custom_success_color)
+            MotionToast.setErrorColor(R.color.custom_error_color)
+            MotionToast.setDeleteColor(R.color.custom_delete_color)
+            MotionToast.setWarningColor(R.color.custom_warning_color)
+            MotionToast.setInfoColor(R.color.custom_info_color)
+        } else {
+            MotionToast.resetToastColors()
+        }
+    }
+
 
     override fun onClick(v: View?) {
         when (v!!.id) {
             R.id.successBtn -> {
-                MotionToast.createToast(this,"Profile Completed!",
-                MotionToast.TOAST_SUCCESS,
-                MotionToast.GRAVITY_BOTTOM,
-                MotionToast.LONG_DURATION,
-                ResourcesCompat.getFont(this,R.font.helvetica_regular))
+                MotionToast.createToast(
+                    this, "Profile Completed!",
+                    MotionToast.TOAST_SUCCESS,
+                    MotionToast.GRAVITY_BOTTOM,
+                    MotionToast.LONG_DURATION,
+                    ResourcesCompat.getFont(this, R.font.helvetica_regular)
+                )
 
             }
             R.id.errorBtn -> {
-                MotionToast.createToast(this,"Profile Update Failed!",
+                MotionToast.createToast(
+                    this, "Profile Update Failed!",
                     MotionToast.TOAST_ERROR,
                     MotionToast.GRAVITY_BOTTOM,
                     MotionToast.LONG_DURATION,
-                    ResourcesCompat.getFont(this,R.font.helvetica_regular))         }
-            R.id.warningBtn ->{
+                    ResourcesCompat.getFont(this, R.font.helvetica_regular)
+                )
+            }
+            R.id.warningBtn -> {
 
-                MotionToast.createToast(this,"Please Fill All The Details!",
+                MotionToast.createToast(
+                    this, "Please Fill All The Details!",
                     MotionToast.TOAST_WARNING,
                     MotionToast.GRAVITY_BOTTOM,
                     MotionToast.LONG_DURATION,
-                    ResourcesCompat.getFont(this,R.font.helvetica_regular))
+                    ResourcesCompat.getFont(this, R.font.helvetica_regular)
+                )
             }
-            R.id.infoBtn ->{
+            R.id.infoBtn -> {
 
                 MotionToast.createColorToast(
                     this, "Color Toast testing here!",
                     MotionToast.TOAST_INFO,
                     MotionToast.GRAVITY_BOTTOM,
                     MotionToast.LONG_DURATION,
-                    ResourcesCompat.getFont(this,R.font.helvetica_regular))
+                    ResourcesCompat.getFont(this, R.font.helvetica_regular)
+                )
             }
-            R.id.deleteBtn ->{
-                MotionToast.createToast(this,"Profile Deleted!",
+            R.id.deleteBtn -> {
+                MotionToast.createToast(
+                    this, "Profile Deleted!",
                     MotionToast.TOAST_DELETE,
                     MotionToast.GRAVITY_BOTTOM,
                     MotionToast.LONG_DURATION,
-                    ResourcesCompat.getFont(this,R.font.helvetica_regular))
+                    ResourcesCompat.getFont(this, R.font.helvetica_regular)
+                )
             }
             R.id.noInternetBtn -> {
                 MotionToast.createToast(
@@ -145,5 +169,9 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClick
         }
 
         return true
+    }
+
+    override fun onCheckedChanged(buttonView: CompoundButton?, isChecked: Boolean) {
+        setToastColors(isChecked)
     }
 }

--- a/app/src/main/java/www/sanju/motiontoast/MainActivity.kt
+++ b/app/src/main/java/www/sanju/motiontoast/MainActivity.kt
@@ -7,7 +7,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
 import kotlinx.android.synthetic.main.activity_main.*
 
-
 class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClickListener,
     CompoundButton.OnCheckedChangeListener {
 
@@ -38,11 +37,15 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClick
             MotionToast.setDeleteColor(R.color.custom_delete_color)
             MotionToast.setWarningColor(R.color.custom_warning_color)
             MotionToast.setInfoColor(R.color.custom_info_color)
+            MotionToast.setSuccessBackgroundColor(R.color.success_bg_color)
+            MotionToast.setErrorBackgroundColor(R.color.error_bg_color)
+            MotionToast.setDeleteBackgroundColor(R.color.delete_bg_color)
+            MotionToast.setWarningBackgroundColor(R.color.warning_bg_color)
+            MotionToast.setInfoBackgroundColor(R.color.info_bg_color)
         } else {
             MotionToast.resetToastColors()
         }
     }
-
 
     override fun onClick(v: View?) {
         when (v!!.id) {
@@ -54,7 +57,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClick
                     MotionToast.LONG_DURATION,
                     ResourcesCompat.getFont(this, R.font.helvetica_regular)
                 )
-
             }
             R.id.errorBtn -> {
                 MotionToast.createToast(
@@ -76,7 +78,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClick
                 )
             }
             R.id.infoBtn -> {
-
                 MotionToast.createColorToast(
                     this, "Color Toast testing here!",
                     MotionToast.TOAST_INFO,
@@ -108,7 +109,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClick
     }
 
     override fun onLongClick(v: View?): Boolean {
-
         when (v!!.id) {
             R.id.successBtn -> {
                 MotionToast.darkToast(

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,6 +14,12 @@
         android:layout_centerInParent="true"
         android:orientation="vertical">
 
+        <Switch
+            android:id="@+id/switch_custom_colors"
+            android:layout_width="200dp"
+            android:text="Custom toast colors"
+            android:layout_height="wrap_content" />
+
         <Button
             android:id="@+id/successBtn"
             android:layout_width="200dp"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 

--- a/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
+++ b/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
@@ -94,7 +94,7 @@ class MotionToast {
 
                     // Background tint color for side view
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.success_color)
+                        ContextCompat.getColorStateList(context, successToastColor)
 
                     // round background color
                     val drawable =
@@ -110,7 +110,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.success_color
+                            successToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_SUCCESS
@@ -164,7 +164,7 @@ class MotionToast {
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.error_color)
+                        ContextCompat.getColorStateList(context, errorToastColor)
 
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
@@ -176,7 +176,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.error_color
+                            errorToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_ERROR
@@ -221,7 +221,7 @@ class MotionToast {
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.warning_color)
+                        ContextCompat.getColorStateList(context, warningToastColor)
 
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
@@ -234,7 +234,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.warning_color
+                            warningToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_WARNING
@@ -280,7 +280,7 @@ class MotionToast {
                     layout.custom_toast_image.startAnimation(pulseAnimation)
 
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.info_color)
+                        ContextCompat.getColorStateList(context, infoToastColor)
 
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
@@ -292,7 +292,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.info_color
+                            infoToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_INFO
@@ -362,7 +362,7 @@ class MotionToast {
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.delete_color)
+                        ContextCompat.getColorStateList(context, deleteToastColor)
 
 
                     val drawable =
@@ -375,7 +375,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.delete_color
+                            deleteToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_DELETE
@@ -423,7 +423,7 @@ class MotionToast {
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.warning_color)
+                        ContextCompat.getColorStateList(context, warningToastColor)
 
 
                     val drawable =
@@ -436,7 +436,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.warning_color
+                            warningToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_NO_INTERNET
@@ -506,7 +506,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.success_color),
+                        ContextCompat.getColor(context, successToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
 
@@ -571,7 +571,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.error_color),
+                        ContextCompat.getColor(context, errorToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
 
@@ -636,7 +636,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.warning_color),
+                        ContextCompat.getColor(context, warningToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
 
@@ -701,7 +701,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.info_color),
+                        ContextCompat.getColor(context, infoToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
 
@@ -767,7 +767,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.delete_color),
+                        ContextCompat.getColor(context, deleteToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
 
@@ -833,7 +833,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.warning_color),
+                        ContextCompat.getColor(context, warningToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
 
@@ -996,7 +996,7 @@ class MotionToast {
                     layout.color_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.error_color
+                            errorToastColor
                         )
                     )
                     layout.color_toast_text.text = TOAST_ERROR
@@ -1066,7 +1066,7 @@ class MotionToast {
                     layout.color_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.warning_color
+                            warningToastColor
                         )
                     )
                     layout.color_toast_text.text = TOAST_WARNING
@@ -1136,7 +1136,7 @@ class MotionToast {
                     layout.color_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.info_color
+                            infoToastColor
                         )
                     )
                     layout.color_toast_text.text = TOAST_INFO
@@ -1207,7 +1207,7 @@ class MotionToast {
                     layout.color_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.delete_color
+                            deleteToastColor
                         )
                     )
                     layout.color_toast_text.text = TOAST_DELETE
@@ -1278,7 +1278,7 @@ class MotionToast {
                     layout.color_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.warning_color
+                            warningToastColor
                         )
                     )
                     layout.color_toast_text.text = TOAST_NO_INTERNET
@@ -1359,7 +1359,7 @@ class MotionToast {
 
                     // Background tint color for side view
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.success_color)
+                        ContextCompat.getColorStateList(context, successToastColor)
 
                     // round background color
                     val drawable =
@@ -1375,7 +1375,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.success_color
+                            successToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_SUCCESS
@@ -1429,7 +1429,7 @@ class MotionToast {
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.error_color)
+                        ContextCompat.getColorStateList(context, errorToastColor)
 
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
@@ -1441,7 +1441,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.error_color
+                            errorToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_ERROR
@@ -1486,7 +1486,7 @@ class MotionToast {
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.warning_color)
+                        ContextCompat.getColorStateList(context, warningToastColor)
 
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
@@ -1499,7 +1499,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.warning_color
+                            warningToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_WARNING
@@ -1545,7 +1545,7 @@ class MotionToast {
                     layout.custom_toast_image.startAnimation(pulseAnimation)
 
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.info_color)
+                        ContextCompat.getColorStateList(context, infoToastColor)
 
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
@@ -1557,7 +1557,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.info_color
+                            infoToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_INFO
@@ -1603,7 +1603,7 @@ class MotionToast {
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.delete_color)
+                        ContextCompat.getColorStateList(context, deleteToastColor)
 
 
                     val drawable =
@@ -1616,7 +1616,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.delete_color
+                            deleteToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_DELETE
@@ -1664,7 +1664,7 @@ class MotionToast {
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
-                        ContextCompat.getColorStateList(context, R.color.warning_color)
+                        ContextCompat.getColorStateList(context, warningToastColor)
 
 
                     val drawable =
@@ -1677,7 +1677,7 @@ class MotionToast {
                     layout.custom_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.warning_color
+                            warningToastColor
                         )
                     )
                     layout.custom_toast_text.text = TOAST_NO_INTERNET

--- a/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
+++ b/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
@@ -50,6 +50,12 @@ class MotionToast {
             warningToastColor = R.color.warning_color
             infoToastColor = R.color.info_color
             deleteToastColor = R.color.delete_color
+
+            successBackgroundToastColor = R.color.success_bg_color
+            errorBackgroundToastColor = R.color.error_bg_color
+            warningBackgroundToastColor = R.color.warning_bg_color
+            infoBackgroundToastColor = R.color.info_bg_color
+            deleteBackgroundToastColor = R.color.delete_bg_color
         }
 
         fun setSuccessColor(color: Int) {
@@ -972,7 +978,10 @@ class MotionToast {
                             R.drawable.ic_check_green
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, successToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -986,12 +995,11 @@ class MotionToast {
                     )
 
                     layout.background = drawable
-
-
+                    
                     layout.color_toast_text.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.success_title_color
+                            successToastColor
                         )
                     )
                     layout.color_toast_text.text = TOAST_SUCCESS
@@ -1042,7 +1050,10 @@ class MotionToast {
                             R.drawable.ic_error_
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, errorToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -1112,7 +1123,10 @@ class MotionToast {
                             R.drawable.ic_warning_yellow
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, warningToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -1182,7 +1196,10 @@ class MotionToast {
                             R.drawable.ic_info_blue
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, infoToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -1252,8 +1269,10 @@ class MotionToast {
                             R.drawable.ic_delete_
                         )
                     )
-
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, deleteToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -1324,7 +1343,10 @@ class MotionToast {
                             R.drawable.ic_no_internet
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, warningToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -1387,12 +1409,8 @@ class MotionToast {
                     toast.show()
 
                 }
-
-
             }
-
         }
-
 
         // all toast CTA
         fun darkColorToast(
@@ -1417,7 +1435,10 @@ class MotionToast {
                             R.drawable.ic_check_green
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, successToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
@@ -1491,6 +1512,10 @@ class MotionToast {
                             R.drawable.ic_error_
                         )
                     )
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, errorToastColor)
+                    )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
@@ -1547,6 +1572,10 @@ class MotionToast {
                             context,
                             R.drawable.ic_warning_yellow
                         )
+                    )
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, warningToastColor)
                     )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
@@ -1606,6 +1635,10 @@ class MotionToast {
                             R.drawable.ic_info_blue
                         )
                     )
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, infoToastColor)
+                    )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
 
@@ -1663,8 +1696,10 @@ class MotionToast {
                             R.drawable.ic_delete_
                         )
                     )
-
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, deleteToastColor)
+                    )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
@@ -1724,8 +1759,10 @@ class MotionToast {
                             R.drawable.ic_no_internet
                         )
                     )
-
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, warningToastColor)
+                    )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =

--- a/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
+++ b/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
@@ -16,7 +16,6 @@ import kotlinx.android.synthetic.main.motion_toast.view.*
 class MotionToast {
     companion object {
 
-
         const val LONG_DURATION = 5000 // 5 seconds
         const val SHORT_DURATION = 2000 // 2 seconds
         const val TOAST_SUCCESS = "SUCCESS"
@@ -26,13 +25,11 @@ class MotionToast {
         const val TOAST_DELETE = "DELETE"
         const val TOAST_NO_INTERNET = "NO INTERNET"
 
-
         const val GRAVITY_TOP = 48
         const val GRAVITY_CENTER = 20
         const val GRAVITY_BOTTOM = 80
 
         private lateinit var layoutInflater: LayoutInflater
-
 
         // all toast CTA
         fun createToast(
@@ -441,10 +438,7 @@ class MotionToast {
                     toast.show()
 
                 }
-
-
             }
-
         }
 
         // all color toast CTA

--- a/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
+++ b/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
@@ -31,6 +31,25 @@ class MotionToast {
 
         private lateinit var layoutInflater: LayoutInflater
 
+        fun config(
+            context: Activity,
+            successColor: Int = R.color.success_color,
+            errorColor: Int = R.color.error_color,
+            warningColor: Int = R.color.warning_color,
+            infoColor: Int = R.color.info_color
+        ) {
+            //Things the developer might want to customize:
+            //Color of Success, Error, warning and info icon/background
+            //Title text (Alternative to WARNING, ERROR, etc.)
+            //Color of text (Default is black)
+
+            //Important: Make all settings optional, add default value
+
+            //Things to consider: Create separate methods fdr each setting (e.g. setSuccessColor())
+
+
+        }
+
         // all toast CTA
         fun createToast(
             context: Activity,
@@ -54,6 +73,13 @@ class MotionToast {
                             R.drawable.ic_check_green
                         )
                     )
+
+                    layout.custom_toast_image.setColorFilter(
+                        ContextCompat.getColor(
+                            context,
+                            R.color.colorAccent
+                        ), android.graphics.PorterDuff.Mode.MULTIPLY
+                    );
 
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)

--- a/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
+++ b/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
@@ -37,6 +37,14 @@ class MotionToast {
         var infoToastColor: Int = R.color.info_color
         var deleteToastColor: Int = R.color.delete_color
 
+        fun resetToastColors() {
+            successToastColor = R.color.success_color
+            errorToastColor = R.color.error_color
+            warningToastColor = R.color.warning_color
+            infoToastColor = R.color.info_color
+            deleteToastColor = R.color.delete_color
+        }
+
         fun setSuccessColor(color: Int) {
             successToastColor = color
         }

--- a/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
+++ b/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
@@ -32,11 +32,17 @@ class MotionToast {
 
         private lateinit var layoutInflater: LayoutInflater
 
-        var successToastColor: Int = R.color.success_color
-        var errorToastColor: Int = R.color.error_color
-        var warningToastColor: Int = R.color.warning_color
-        var infoToastColor: Int = R.color.info_color
-        var deleteToastColor: Int = R.color.delete_color
+        private var successToastColor: Int = R.color.success_color
+        private var errorToastColor: Int = R.color.error_color
+        private var warningToastColor: Int = R.color.warning_color
+        private var infoToastColor: Int = R.color.info_color
+        private var deleteToastColor: Int = R.color.delete_color
+
+        private var successBackgroundToastColor: Int = R.color.success_bg_color
+        private var errorBackgroundToastColor: Int = R.color.error_bg_color
+        private var warningBackgroundToastColor: Int = R.color.warning_bg_color
+        private var infoBackgroundToastColor: Int = R.color.info_bg_color
+        private var deleteBackgroundToastColor: Int = R.color.delete_bg_color
 
         fun resetToastColors() {
             successToastColor = R.color.success_color
@@ -50,20 +56,40 @@ class MotionToast {
             successToastColor = color
         }
 
+        fun setSuccessBackgroundColor(color: Int) {
+            successBackgroundToastColor = color
+        }
+
         fun setErrorColor(color: Int) {
             errorToastColor = color
+        }
+
+        fun setErrorBackgroundColor(color: Int) {
+            errorBackgroundToastColor = color
         }
 
         fun setWarningColor(color: Int) {
             warningToastColor = color
         }
 
+        fun setWarningBackgroundColor(color: Int) {
+            warningBackgroundToastColor = color
+        }
+
         fun setInfoColor(color: Int) {
             infoToastColor = color
         }
 
+        fun setInfoBackgroundColor(color: Int) {
+            infoBackgroundToastColor = color
+        }
+
         fun setDeleteColor(color: Int) {
             deleteToastColor = color
+        }
+
+        fun setDeleteBackgroundColor(color: Int) {
+            deleteBackgroundToastColor = color
         }
 
         // all toast CTA
@@ -106,7 +132,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.success_bg_color),
+                        ContextCompat.getColor(context, successBackgroundToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
 
@@ -179,7 +205,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.error_bg_color),
+                        ContextCompat.getColor(context, errorBackgroundToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
                     layout.background = drawable
@@ -240,7 +266,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.warning_bg_color),
+                        ContextCompat.getColor(context, warningBackgroundToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
 
@@ -303,7 +329,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.info_bg_color),
+                        ContextCompat.getColor(context, infoBackgroundToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
                     layout.background = drawable
@@ -384,11 +410,10 @@ class MotionToast {
                     layout.colorView.backgroundTintList =
                         ContextCompat.getColorStateList(context, deleteToastColor)
 
-
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.delete_bg_color),
+                        ContextCompat.getColor(context, deleteBackgroundToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
                     layout.background = drawable
@@ -451,7 +476,7 @@ class MotionToast {
                     val drawable =
                         ContextCompat.getDrawable(context, R.drawable.toast_round_background)
                     drawable?.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context, R.color.warning_bg_color),
+                        ContextCompat.getColor(context, warningBackgroundToastColor),
                         PorterDuff.Mode.MULTIPLY
                     )
                     layout.background = drawable
@@ -519,6 +544,10 @@ class MotionToast {
                             R.drawable.ic_check_green
                         )
                     )
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, successToastColor)
+                    )
 
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
@@ -584,7 +613,10 @@ class MotionToast {
                             R.drawable.ic_error_
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, errorToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -649,7 +681,10 @@ class MotionToast {
                             R.drawable.ic_warning_yellow
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, warningToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -714,7 +749,10 @@ class MotionToast {
                             R.drawable.ic_info_blue
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, infoToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -779,8 +817,10 @@ class MotionToast {
                             R.drawable.ic_delete_
                         )
                     )
-
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, deleteToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)
@@ -846,7 +886,10 @@ class MotionToast {
                             R.drawable.ic_no_internet
                         )
                     )
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.color_toast_image.drawable),
+                        ContextCompat.getColor(context, warningToastColor)
+                    )
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.color_toast_image.startAnimation(pulseAnimation)

--- a/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
+++ b/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
@@ -10,6 +10,7 @@ import android.view.LayoutInflater
 import android.view.animation.AnimationUtils
 import android.widget.Toast
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.DrawableCompat
 import kotlinx.android.synthetic.main.full_color_toast.view.*
 import kotlinx.android.synthetic.main.motion_toast.view.*
 
@@ -88,13 +89,10 @@ class MotionToast {
                             R.drawable.ic_check_green
                         )
                     )
-
-                    layout.custom_toast_image.setColorFilter(
-                        ContextCompat.getColor(
-                            context,
-                            R.color.colorAccent
-                        ), android.graphics.PorterDuff.Mode.MULTIPLY
-                    );
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, successToastColor)
+                    )
 
                     // Pulse Animation for Icon
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
@@ -169,6 +167,10 @@ class MotionToast {
                             R.drawable.ic_error_
                         )
                     )
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, errorToastColor)
+                    )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
@@ -225,6 +227,10 @@ class MotionToast {
                             context,
                             R.drawable.ic_warning_yellow
                         )
+                    )
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, warningToastColor)
                     )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
@@ -283,6 +289,10 @@ class MotionToast {
                             context,
                             R.drawable.ic_info_blue
                         )
+                    )
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, infoToastColor)
                     )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
@@ -365,8 +375,10 @@ class MotionToast {
                             R.drawable.ic_delete_
                         )
                     )
-
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, deleteToastColor)
+                    )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =
@@ -426,8 +438,10 @@ class MotionToast {
                             R.drawable.ic_no_internet
                         )
                     )
-
-
+                    DrawableCompat.setTint(
+                        DrawableCompat.wrap(layout.custom_toast_image.drawable),
+                        ContextCompat.getColor(context, warningToastColor)
+                    )
                     val pulseAnimation = AnimationUtils.loadAnimation(context, R.anim.pulse)
                     layout.custom_toast_image.startAnimation(pulseAnimation)
                     layout.colorView.backgroundTintList =

--- a/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
+++ b/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
@@ -31,23 +31,30 @@ class MotionToast {
 
         private lateinit var layoutInflater: LayoutInflater
 
-        fun config(
-            context: Activity,
-            successColor: Int = R.color.success_color,
-            errorColor: Int = R.color.error_color,
-            warningColor: Int = R.color.warning_color,
-            infoColor: Int = R.color.info_color
-        ) {
-            //Things the developer might want to customize:
-            //Color of Success, Error, warning and info icon/background
-            //Title text (Alternative to WARNING, ERROR, etc.)
-            //Color of text (Default is black)
+        var successToastColor: Int = R.color.success_color
+        var errorToastColor: Int = R.color.error_color
+        var warningToastColor: Int = R.color.warning_color
+        var infoToastColor: Int = R.color.info_color
+        var deleteToastColor: Int = R.color.delete_color
 
-            //Important: Make all settings optional, add default value
+        fun setSuccessColor(color: Int) {
+            successToastColor = color
+        }
 
-            //Things to consider: Create separate methods fdr each setting (e.g. setSuccessColor())
+        fun setErrorColor(color: Int) {
+            errorToastColor = color
+        }
 
+        fun setWarningColor(color: Int) {
+            warningToastColor = color
+        }
 
+        fun setInfoColor(color: Int) {
+            infoToastColor = color
+        }
+
+        fun setDeleteColor(color: Int) {
+            deleteToastColor = color
         }
 
         // all toast CTA

--- a/motiontoast/src/main/res/layout/motion_toast.xml
+++ b/motiontoast/src/main/res/layout/motion_toast.xml
@@ -12,7 +12,6 @@
         android:layout_height="100dp"
         android:background="@drawable/color_view_background" />
 
-
     <ImageView
         android:id="@+id/custom_toast_image"
         android:layout_width="40dp"
@@ -20,7 +19,6 @@
         android:layout_centerVertical="true"
         android:layout_marginStart="25dp"
         android:src="@drawable/ic_info_yellow" />
-
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -30,7 +28,6 @@
         android:layout_marginStart="55dp"
         android:orientation="vertical"
         android:padding="20dp">
-
 
         <TextView
             android:id="@+id/custom_toast_text"
@@ -53,7 +50,6 @@
             android:text="Hello this is demo warning!"
             android:textColor="@android:color/black"
             android:textSize="16sp" />
-
     </LinearLayout>
 
 </RelativeLayout>

--- a/motiontoast/src/main/res/values/colors.xml
+++ b/motiontoast/src/main/res/values/colors.xml
@@ -5,7 +5,6 @@
     <color name="colorAccent">#0340DA</color>
 
     <!--    Background Colors-->
-
     <color name="warning_color">#FBC02D</color>
     <color name="error_color">#D50000</color>
     <color name="success_color">#17B978</color>

--- a/motiontoast/src/main/res/values/colors.xml
+++ b/motiontoast/src/main/res/values/colors.xml
@@ -11,6 +11,14 @@
     <color name="info_color">#0340DA</color>
     <color name="delete_color">#0288D1</color>
 
+
+    <!--    Custom Colors-->
+    <color name="custom_warning_color">#FFFF00</color>
+    <color name="custom_error_color">#800000</color>
+    <color name="custom_success_color">#00FF00</color>
+    <color name="custom_info_color">#00008B</color>
+    <color name="custom_delete_color">#ADD8E6</color>
+
     <!--    Background Transparent Colors-->
     <color name="warning_bg_color">#33FBC02D</color>
     <color name="error_bg_color">#33D32F2F</color>

--- a/motiontoast/src/main/res/values/colors.xml
+++ b/motiontoast/src/main/res/values/colors.xml
@@ -28,7 +28,5 @@
 
     <!--    Dark Toast bg-->
     <color name="dark_bg_color">#2F3032</color>
-    <color name="success_title_color">#17B978</color>
-
 
 </resources>


### PR DESCRIPTION
### Description:
This PR adds several new methods to the library, that lets us customize the colors used in the toast messages on the request of our ux/ui designers. These changes will allow us to use this library in our applications.
This PR also remove unnecessary empty lines and extends the sample app to showcase the new features.

![gif](https://i.imgur.com/EdlNjsi.png)

![gif](https://i.imgur.com/wWsku0p.png)

### Customizability:
The following colors can now be customized:

- successColor
- errorColor
- warningColor
- infoColor
- deleteColor

### Usage:
To change the color of the success toast, you need to call the following method:
`MotionToast.setSuccessColor(R.color.custom_success_color)
`MotionToast.setSuccessBackgroundColor(R.color.success_bg_color)`

If you want to reset all custom toast colors and use the default colors, call:
`MotionToast.resetToastColors()`

### Conclusion
There should not be any compatibility issues with these changes.
I'm open for feedback, if you want we can discuss my changes. Also feel free to adjust the naming of the methods to your liking. 
At first, I planned to create just one config() methods, that changes all the colors at once, but in the end I decided to create for every color adjustment one separate methods, because this way you don't need to insert 10+ colors into one method and you it's cleaner.
Another idea for the future, would be to allow customizing the title of the toast message. This would come in handy, if you are supporting multiple languages and dont wan't to display the title "DELETE" in foreign language settings. The devs also might want to customize the wording to their liking.