### PR TITLE
Fixed Toast Gravity(TOP & CENTER) not aligned properly

### DIFF
--- a/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
+++ b/motiontoast/src/main/java/www/sanju/motiontoast/MotionToast.kt
@@ -31,8 +31,8 @@ class MotionToast {
         const val TOAST_INFO = "INFO"
         const val TOAST_DELETE = "DELETE"
         const val TOAST_NO_INTERNET = "NO INTERNET"
-        const val GRAVITY_TOP = 50
-        const val GRAVITY_CENTER = 20
+        const val GRAVITY_TOP = 48
+        const val GRAVITY_CENTER = 16
         const val GRAVITY_BOTTOM = 80
 
         private lateinit var layoutInflater: LayoutInflater


### PR DESCRIPTION
Fixed issue #31 
By adjusting the values for Gravity TOP & CENTER, the toast centers properly.

**Before**
<img src="https://user-images.githubusercontent.com/35205214/126911026-9d592474-df5f-4792-b5d7-5703bf7cfb6e.png" style="max-width:100%;" width="300">

**After**
<img src="https://user-images.githubusercontent.com/35205214/126911045-b11ccd48-27d9-4fc7-b391-a330aff813b3.png" style="max-width:100%;" width="300">
